### PR TITLE
Cast state

### DIFF
--- a/internal/api/states.go
+++ b/internal/api/states.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/hashicorp/terraform/state"
+	"github.com/hashicorp/terraform/terraform"
 )
 
 func (s *server) InsertState(w http.ResponseWriter, r *http.Request) {
@@ -24,7 +25,7 @@ func (s *server) InsertState(w http.ResponseWriter, r *http.Request) {
 		source = "direct"
 	}
 
-	var document interface{}
+	var document terraform.State
 	decoder := json.NewDecoder(r.Body)
 	err := decoder.Decode(&document)
 	if err != nil {

--- a/internal/api/states.go
+++ b/internal/api/states.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/camptocamp/terradb/internal/storage"
 	"github.com/gorilla/mux"
 	"github.com/hashicorp/terraform/state"
 	"github.com/hashicorp/terraform/terraform"
@@ -98,13 +99,11 @@ func (s *server) GetState(w http.ResponseWriter, r *http.Request) {
 	}
 
 	document, err := s.st.GetState(params["name"], serial)
-	if err != nil {
-		err500(err, "failed to retrieve latest state", w)
-		return
-	}
-
-	if document == nil {
+	if err == storage.ErrNoDocuments {
 		w.WriteHeader(http.StatusNotFound)
+		return
+	} else if err != nil {
+		err500(err, "failed to retrieve latest state", w)
 		return
 	}
 

--- a/internal/storage/mongodb.go
+++ b/internal/storage/mongodb.go
@@ -172,11 +172,10 @@ func (st *MongoDBStorage) ListStates(page_num, page_size int) (states []Document
 
 // GetState retrieves a Terraform state, at a given serial.
 // If serial is 0, it gets the latest serial
-func (st *MongoDBStorage) GetState(name string, serial int) (document interface{}, err error) {
+func (st *MongoDBStorage) GetState(name string, serial int) (doc Document, err error) {
 	collection := st.client.Database("terradb").Collection("terraform_states")
 	ctx, _ := context.WithTimeout(context.Background(), 5*time.Second)
 
-	var data map[string]interface{}
 	filter := map[string]interface{}{
 		"name": name,
 	}
@@ -188,19 +187,15 @@ func (st *MongoDBStorage) GetState(name string, serial int) (document interface{
 	err = collection.FindOne(
 		ctx, filter,
 		options.FindOne().SetSort(bson.M{"state.serial": -1}),
-	).Decode(&data)
+	).Decode(&doc)
 
 	if err == mongo.ErrNoDocuments {
-		return nil, nil
+		return doc, ErrNoDocuments
 	} else if err != nil {
 		err = fmt.Errorf("failed to decode state: %v", err)
 		return
 	}
 
-	document, ok := data["state"]
-	if !ok {
-		err = fmt.Errorf("state file not found")
-	}
 	return
 }
 

--- a/internal/storage/mongodb.go
+++ b/internal/storage/mongodb.go
@@ -8,6 +8,7 @@ import (
 
 	//log "github.com/sirupsen/logrus"
 
+	"github.com/hashicorp/terraform/terraform"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
@@ -204,26 +205,15 @@ func (st *MongoDBStorage) GetState(name string, serial int) (document interface{
 }
 
 // InsertState adds a Terraform state to the database.
-func (st *MongoDBStorage) InsertState(doc interface{}, timestamp, source, name string) (err error) {
+func (st *MongoDBStorage) InsertState(doc terraform.State, timestamp, source, name string) (err error) {
 	collection := st.client.Database("terradb").Collection("terraform_states")
 	ctx, _ := context.WithTimeout(context.Background(), 5*time.Second)
-
-	v, ok := doc.(map[string]interface{})
-	if !ok {
-		err = fmt.Errorf("failed to unmarshal document")
-		return
-	}
-
-	serial, ok := v["serial"].(int)
-	if !ok {
-		serial = 0
-	}
 
 	var query interface{}
 	json.Unmarshal([]byte(fmt.Sprintf(`{
 		"state.serial": "%v",
 		"name": "%s"
-	}`, serial, name)), &query)
+	}`, doc.Serial, name)), &query)
 
 	data := &mongoDoc{
 		Timestamp: timestamp,

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -1,6 +1,7 @@
 package storage
 
 import (
+	"errors"
 	"time"
 
 	"github.com/hashicorp/terraform/terraform"
@@ -14,11 +15,14 @@ type Document struct {
 	State        *terraform.State `json:"state"`
 }
 
+// ErrNoDocuments
+var ErrNoDocuments = errors.New("No document found")
+
 // Storage is an abstraction over database engines
 type Storage interface {
 	GetName() string
 	ListStates(page_num, page_size int) (states []Document, err error)
-	GetState(name string, serial int) (document interface{}, err error)
+	GetState(name string, serial int) (doc Document, err error)
 	InsertState(document terraform.State, timestamp, source, name string) (err error)
 	RemoveState(name string) (err error)
 	GetLockStatus(name string) (lockStatus interface{}, err error)

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -19,7 +19,7 @@ type Storage interface {
 	GetName() string
 	ListStates(page_num, page_size int) (states []Document, err error)
 	GetState(name string, serial int) (document interface{}, err error)
-	InsertState(document interface{}, timestamp, source, name string) (err error)
+	InsertState(document terraform.State, timestamp, source, name string) (err error)
 	RemoveState(name string) (err error)
 	GetLockStatus(name string) (lockStatus interface{}, err error)
 	LockState(name string, lockData interface{}) (err error)


### PR DESCRIPTION
We currently feed the state as an `interface{}` to MongoDB. This leads to issues when marshalling/unmarshalling to JSON because of the field names, which do not match the DB fields.

By using the internal `terraform.State` struct, we make sure to map to known fields that can be marshalled/unmarshalled consistently.
