### PR TITLE
Make private State and LockInfo types

### DIFF
--- a/internal/api/states.go
+++ b/internal/api/states.go
@@ -10,8 +10,6 @@ import (
 
 	"github.com/camptocamp/terradb/internal/storage"
 	"github.com/gorilla/mux"
-	"github.com/hashicorp/terraform/state"
-	"github.com/hashicorp/terraform/terraform"
 )
 
 func (s *server) InsertState(w http.ResponseWriter, r *http.Request) {
@@ -27,7 +25,7 @@ func (s *server) InsertState(w http.ResponseWriter, r *http.Request) {
 		source = "direct"
 	}
 
-	var document terraform.State
+	var document storage.State
 	decoder := json.NewDecoder(r.Body)
 	err := decoder.Decode(&document)
 	if err != nil {
@@ -125,7 +123,7 @@ func (s *server) RemoveState(w http.ResponseWriter, r *http.Request) {
 func (s *server) LockState(w http.ResponseWriter, r *http.Request) {
 	params := mux.Vars(r)
 
-	var currentLock, remoteLock state.LockInfo
+	var currentLock, remoteLock storage.LockInfo
 
 	body, err := ioutil.ReadAll(r.Body)
 	if err != nil {
@@ -171,7 +169,7 @@ func (s *server) LockState(w http.ResponseWriter, r *http.Request) {
 func (s *server) UnlockState(w http.ResponseWriter, r *http.Request) {
 	params := mux.Vars(r)
 
-	var lockData state.LockInfo
+	var lockData storage.LockInfo
 
 	body, err := ioutil.ReadAll(r.Body)
 	if err != nil {

--- a/internal/storage/mongodb.go
+++ b/internal/storage/mongodb.go
@@ -8,8 +8,6 @@ import (
 
 	//log "github.com/sirupsen/logrus"
 
-	"github.com/hashicorp/terraform/state"
-	"github.com/hashicorp/terraform/terraform"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
@@ -63,7 +61,7 @@ func (*MongoDBStorage) GetName() string {
 }
 
 // GetLockStatus returns a Terraform lock.
-func (st *MongoDBStorage) GetLockStatus(name string) (lockStatus state.LockInfo, err error) {
+func (st *MongoDBStorage) GetLockStatus(name string) (lockStatus LockInfo, err error) {
 	collection := st.client.Database("terradb").Collection("locks")
 	ctx, _ := context.WithTimeout(context.Background(), 5*time.Second)
 
@@ -82,7 +80,7 @@ func (st *MongoDBStorage) GetLockStatus(name string) (lockStatus state.LockInfo,
 }
 
 // LockState locks a Terraform state.
-func (st *MongoDBStorage) LockState(name string, lockData state.LockInfo) (err error) {
+func (st *MongoDBStorage) LockState(name string, lockData LockInfo) (err error) {
 	collection := st.client.Database("terradb").Collection("locks")
 	ctx, _ := context.WithTimeout(context.Background(), 5*time.Second)
 
@@ -95,7 +93,7 @@ func (st *MongoDBStorage) LockState(name string, lockData state.LockInfo) (err e
 }
 
 // UnlockState unlocks a Terraform state.
-func (st *MongoDBStorage) UnlockState(name string, lockData state.LockInfo) (err error) {
+func (st *MongoDBStorage) UnlockState(name string, lockData LockInfo) (err error) {
 	collection := st.client.Database("terradb").Collection("locks")
 	ctx, _ := context.WithTimeout(context.Background(), 5*time.Second)
 
@@ -158,7 +156,7 @@ func (st *MongoDBStorage) ListStates(page_num, page_size int) (coll DocumentColl
 
 // GetState retrieves a Terraform state, at a given serial.
 // If serial is 0, it gets the latest serial
-func (st *MongoDBStorage) GetState(name string, serial int) (state terraform.State, err error) {
+func (st *MongoDBStorage) GetState(name string, serial int) (state State, err error) {
 	collection := st.client.Database("terradb").Collection("terraform_states")
 	ctx, _ := context.WithTimeout(context.Background(), 5*time.Second)
 
@@ -189,7 +187,7 @@ func (st *MongoDBStorage) GetState(name string, serial int) (state terraform.Sta
 }
 
 // InsertState adds a Terraform state to the database.
-func (st *MongoDBStorage) InsertState(doc terraform.State, timestamp, source, name string) (err error) {
+func (st *MongoDBStorage) InsertState(doc State, timestamp, source, name string) (err error) {
 	collection := st.client.Database("terradb").Collection("terraform_states")
 	ctx, _ := context.WithTimeout(context.Background(), 5*time.Second)
 

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -8,12 +8,18 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
+// State is a Terraform state
+type State terraform.State
+
+// LockInfo is a State lock info
+type LockInfo state.LockInfo
+
 // Document associates a name and a state
 type Document struct {
-	Timestamp    string           `json:"-"`
-	LastModified time.Time        `json:"last_modified"`
-	Name         string           `json:"name"`
-	State        *terraform.State `json:"state"`
+	Timestamp    string    `json:"-"`
+	LastModified time.Time `json:"last_modified"`
+	Name         string    `json:"name"`
+	State        *State    `json:"state"`
 }
 
 // DocumentCollection is a collection of Document, with metadata
@@ -32,11 +38,11 @@ var ErrNoDocuments = errors.New("No document found")
 type Storage interface {
 	GetName() string
 	ListStates(page_num, page_size int) (coll DocumentCollection, err error)
-	GetState(name string, serial int) (state terraform.State, err error)
-	InsertState(document terraform.State, timestamp, source, name string) (err error)
+	GetState(name string, serial int) (state State, err error)
+	InsertState(document State, timestamp, source, name string) (err error)
 	RemoveState(name string) (err error)
-	GetLockStatus(name string) (lockStatus state.LockInfo, err error)
-	LockState(name string, lockData state.LockInfo) (err error)
-	UnlockState(name string, lockData state.LockInfo) (err error)
+	GetLockStatus(name string) (lockStatus LockInfo, err error)
+	LockState(name string, lockData LockInfo) (err error)
+	UnlockState(name string, lockData LockInfo) (err error)
 	ListStateSerials(name string, page_num, page_size int) (coll DocumentCollection, err error)
 }


### PR DESCRIPTION
This clarifies private interfaces and limits dependencies to Terraform
libs to storage.go