### PR TITLE
[WIP] add InsertPlan interface

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -53,6 +53,7 @@ func StartServer(cfg *API, st storage.Storage) {
 	apiRtr.HandleFunc("/states/{name}/serials", s.ListStateSerials).Methods("GET")
 	apiRtr.HandleFunc("/resources/{state}/{module}/{name}", s.GetResource).Methods("GET")
 	apiRtr.HandleFunc("/resources/{state}/{name}", s.GetResource).Methods("GET")
+	apiRtr.HandleFunc("/plans/${workspace}", s.InsertPlan).Methods("POST")
 
 	c := cors.New(cors.Options{
 		AllowedOrigins: []string{"*"},

--- a/internal/api/plans.go
+++ b/internal/api/plans.go
@@ -1,0 +1,9 @@
+package api
+
+import (
+	"net/http"
+)
+
+func (s *server) InsertPlan(w http.ResponseWriter, r *http.Request) {
+	return
+}

--- a/internal/storage/mongodb.go
+++ b/internal/storage/mongodb.go
@@ -341,6 +341,11 @@ func getResource(state State, module, name string) (res Resource, err error) {
 	return res, ErrNoDocuments
 }
 
+// InsertPlan adds a Terraform plan to the database
+func (st *MongoDBStorage) InsertPlan(doc Plan, timestamp, source, name string) (err error) {
+	return
+}
+
 func paginateReq(req mongo.Pipeline, pageNum, pageSize int) (pl mongo.Pipeline) {
 	skips := pageSize * (pageNum - 1)
 

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -7,6 +7,10 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
+// Plan is a Terraform plan
+type Plan struct {
+}
+
 // State is a Terraform state
 type State struct {
 	LastModified time.Time `json:"last_modified"`
@@ -113,4 +117,5 @@ type Storage interface {
 	UnlockState(name string, lockData LockInfo) (err error)
 	ListStateSerials(name string, pageNum, pageSize int) (coll StateCollection, err error)
 	GetResource(state, module, name string) (res Resource, err error)
+	InsertPlan(document Plan, timestamp, source, name string) (err error)
 }


### PR DESCRIPTION
Since v0.12, Terraform allows showing the plan in json format using this:
```shell
$ terraform plan -out=myplan
$ terraform show myplan
```
We should add an API endpoint to store this plans in TerraDB so that we can build Grafana Dashboard showing the convergence state of our workspaces.